### PR TITLE
start of manuscript subject taxonomy/collection page #78

### DIFF
--- a/ucdlib-special/includes/tax-subject.php
+++ b/ucdlib-special/includes/tax-subject.php
@@ -8,6 +8,15 @@ class UCDLibPluginSpecialTaxSubject {
     add_action( 'init', array($this, 'register') );
     add_action( 'admin_menu', array($this, 'add_to_menu'));
     add_action( 'parent_file',  array($this, 'expand_parent_menu') );
+    add_action( 'init', [$this, 'register_term_meta'] );
+    add_action( 'widgets_init', [$this, 'register_sidebar'] );
+    add_action($this->slug . '_add_form_fields', array($this, 'render_term_meta'), 4, 1);
+    add_action($this->slug . '_edit_form_fields', array($this, 'render_term_meta'), 4, 1);
+    add_action('edited_' . $this->slug, array($this, 'save_term_meta'), 10, 1);
+    add_action('create_' . $this->slug, array($this, 'save_term_meta'), 10, 2);
+    add_action('pre_get_posts', array($this, 'sort_by_ascending'));
+    add_filter( 'ucd-theme/context/taxonomy', array($this, 'set_context') );
+    add_filter( 'ucd-theme/templates/taxonomy', array($this, 'set_template'), 10, 2 );
   }
 
   // register taxonomy
@@ -49,7 +58,6 @@ class UCDLibPluginSpecialTaxSubject {
       [$this->config->postTypes['collection']],
       $args
     );
-    
   }
 
   // add to plugin admin menu
@@ -66,5 +74,80 @@ class UCDLibPluginSpecialTaxSubject {
     return $parent_file;
   }
 
+  // register metadata associated with each taxonomy term
+  public function register_term_meta(){
+    register_term_meta($this->slug, 'subjectHeading', ['type' => 'string', 'single' => true, 'show_in_rest' => true]);
+  }
+
+  // renders custom meta fields on add/edit subject forms
+  public function render_term_meta( $term ){
+    $context = array(
+      'current_filter' => current_filter(),
+      'term' => $term
+    );
+    if ( is_object($term) ) {
+      $context['subjectHeading'] = get_term_meta($term->term_id, 'subjectHeading', true);
+    }
+    Timber::render('@' . $this->config->postTypes['collection'] . '/admin/tax-subject-meta.twig' , $context);
+  }
+
+  // saves custom meta fields on add/edit subject forms
+  public function save_term_meta( $term_id ){
+    if (!isset($_POST['subjectHeading'])) {
+      return;
+    }
+    update_term_meta($term_id, 'subjectHeading', sanitize_text_field($_POST['subjectHeading']));
+  }
+
+  // add data to view context
+  public function set_context($context){
+    if ( $context['term']->taxonomy !== $this->slug ) return $context;
+
+    // add breadcrumbs
+    $manuscriptLanderCrumbs = [
+      [
+        'link' => '/',
+        'title' => 'Home'
+      ],
+      [
+        'link' => '/archives-and-special-collections',
+        'title' => 'Archives and Special Collections'
+      ], 
+      [
+        'link' => '/archives-and-special-collections/manuscripts',
+        'title' => 'Manuscripts'
+      ]
+    ];
+    $context['breadcrumbs'] = array_merge($manuscriptLanderCrumbs, [['title' => $context['term']->name]]);
+
+    $context['sidebar'] = trim(Timber::get_widgets( $this->slug ));    
+    return $context;
+  }
+  
+  // set the twig to call
+  public function set_template($templates, $context){
+    if ( $context['term']->taxonomy !== $this->slug ) return $templates;
+    
+    $templates = array_merge( array("@" . $this->config->slug . "/subject.twig"), $templates );
+    return $templates;
+  }
+
+  function sort_by_ascending($query){
+      $query->set('orderby', 'title' );
+      $query->set('order', 'ASC' );
+  }
+
+  // edit with Appearance>>Widgets
+  public function register_sidebar(){
+    register_sidebar(
+      array(
+        'id'            => $this->slug,
+        'name'          => "Manuscripts by Subject",
+        'description'   => "Sidebar widgets for manuscripts by subject.",
+        'before_widget' => '',
+        'after_widget' => ''
+      )
+    );
+  }
   
 }

--- a/ucdlib-special/views/admin/tax-subject-meta.twig
+++ b/ucdlib-special/views/admin/tax-subject-meta.twig
@@ -1,0 +1,25 @@
+{% macro label() %}
+  <label for="subjectHeading">Subject Heading</label>
+{% endmacro %}
+
+
+{% macro input(subjectHeading) %}
+  <input type="text" size="40" value="{{subjectHeading}}" id="subjectHeading" name="subjectHeading">
+  <p class="description">The heading to display at the top of the list of collections in this subject</p>
+{% endmacro %}
+
+{% if current_filter ends with 'edit_form_fields' %}
+  <tr class="form-field">
+    <th valign="top" scope="row">{{_self.label()}}</th>
+      <td>
+        {{_self.input(subjectHeading)}}
+      </td>
+  </tr> 
+
+{% elseif current_filter ends with 'add_form_fields' %}
+  <div class="form-field">
+    {{_self.label()}}
+    {{_self.input(subjectHeading)}}
+  </div>  
+
+{% endif %}

--- a/ucdlib-special/views/macros/subject.twig
+++ b/ucdlib-special/views/macros/subject.twig
@@ -1,0 +1,10 @@
+{% macro teaser(collection) %}
+  <div class="vm-teaser__body">
+    <h3 class="vm-teaser__title" style="display: inline-block;">
+      <a href="{{collection.link}}" style="text-decoration: underline; color: var(--ucd-blue-80)">{{collection.title}}</a> 
+    </h3> ({{collection.callNumber}})
+    <div class="vm-teaser__summary">
+      {{ collection.description({words: 25}) }}
+    </div>
+  </div>
+{% endmacro %}

--- a/ucdlib-special/views/subject.twig
+++ b/ucdlib-special/views/subject.twig
@@ -1,0 +1,41 @@
+{% extends getUcdTemplate('base') %}
+
+{% from '@ucdlib-special/macros/subject.twig' import teaser %}
+{% from getUcdMacro('links') import pagination %}
+
+{% block content_container %}
+
+{# {{ dump(exhibitsLanderCrumbs) }} #}
+<div class="l-container {{sidebar ? 'l-basic--flipped'}}">
+  <div class="l-content">
+
+    <div class="panel o-box">
+        {% if posts %}
+            <div class="panel panel--intro o-box">
+            <h2 class="panel__title">{{term.subjectHeading}}</h2>
+            <section>
+                <p>{{term.description}}</p>
+            </section>
+            </div>
+
+            <ul class="list--arrow">
+            {% for post in posts %}
+                <li style="margin-bottom: 1em;">
+                    {{ teaser(post) }}
+                </li>
+            {% endfor %}
+            </ul>
+        {{ pagination({"pagination": posts.pagination}) }}
+        
+        {% else %}
+        <div class="alert">No {{title}} posts found!</div>
+        {% endif %}
+    </div>
+    </div>
+    {% if sidebar %}
+        <div class="l-sidebar-second">
+        {{sidebar}}
+        </div>
+    {% endif %}
+    </div>
+{% endblock %}


### PR DESCRIPTION
@spelkey-ucd one thing I'm unsure of is building the breadcrumbs in `tax-subject.php` on line 107. I didn't totally understand the acf exhibit code, perhaps that will need to be changed to follow a similar pattern